### PR TITLE
Reducing PVC storage requests

### DIFF
--- a/__snapshots__/main.test.ts.snap
+++ b/__snapshots__/main.test.ts.snap
@@ -211,6 +211,158 @@ spec:
 "
 `;
 
+exports[`Engine 1`] = `
+"apiVersion: v1
+kind: ServiceAccount
+imagePullSecrets:
+  - name: gcr-access-token
+metadata:
+  labels:
+    app: engine
+  name: engine-sa
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: engine
+  name: engine-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  job: |
+    metadata:
+      labels:
+        engineJob: 'true'
+        suffix: svcs
+    spec:
+      template:
+        spec:
+          serviceAccount: engine-sa
+          containers:
+            - image: gcr.io/tensorleap/engine:master-1234568-stable
+              name: engine
+              env:
+                - name: JOB_PAYLOAD
+                - name: PY_CONFIG
+                  value: /app/config/config.yaml
+                - name: ELASTIC_HOST
+                  value: http://elasticsearch-master.default:9200
+                - name: SESSION_BUCKET
+                  value: session
+                - name: RABBIT_HOST
+                  value: rabbitmq-headless
+                - name: RABBIT_USER
+                  value: user
+                - name: RABBIT_PASSWORD
+                  value: 3e3abae2-6325-11ec-90d6-0242ac120003
+                - name: FEEDBACK_TOPIC
+                  value: feedback
+                - name: SUBSCRIBER_TOPIC
+                  value: job-control-channel
+                - name: STORAGE_PROVIDER
+                  value: minio
+                - name: STORAGE_ENDPOINT
+                  value: dummy-minio
+                - name: STORAGE_PORT
+                  value: '9000'
+                - name: HMAC_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: rootUser
+                - name: HMAC_ACCESS_KEY_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: rootPassword
+              volumeMounts:
+                - name: engine-pvc
+                  mountPath: /nfs/
+          restartPolicy: Never
+          volumes:
+            - name: engine-pvc
+              presistentVolumeClaim:
+                claimName: engine-pvc
+metadata:
+  labels:
+    app: engine
+  name: engine-job-template-pytop-svcs
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  job: |
+    metadata:
+      labels:
+        engineJob: 'true'
+        suffix: k80
+    spec:
+      template:
+        spec:
+          serviceAccount: engine-sa
+          containers:
+            - image: gcr.io/tensorleap/engine:master-1234568-stable
+              name: engine
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+              env:
+                - name: JOB_PAYLOAD
+                - name: PY_CONFIG
+                  value: /app/config/config.yaml
+                - name: ELASTIC_HOST
+                  value: http://elasticsearch-master.default:9200
+                - name: SESSION_BUCKET
+                  value: session
+                - name: RABBIT_HOST
+                  value: rabbitmq-headless
+                - name: RABBIT_USER
+                  value: user
+                - name: RABBIT_PASSWORD
+                  value: 3e3abae2-6325-11ec-90d6-0242ac120003
+                - name: FEEDBACK_TOPIC
+                  value: feedback
+                - name: SUBSCRIBER_TOPIC
+                  value: job-control-channel
+                - name: STORAGE_PROVIDER
+                  value: minio
+                - name: STORAGE_ENDPOINT
+                  value: dummy-minio
+                - name: STORAGE_PORT
+                  value: '9000'
+                - name: HMAC_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: rootUser
+                - name: HMAC_ACCESS_KEY_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: rootPassword
+              volumeMounts:
+                - name: engine-pvc
+                  mountPath: /nfs/
+          restartPolicy: Never
+          volumes:
+            - name: engine-pvc
+              presistentVolumeClaim:
+                claimName: engine-pvc
+metadata:
+  labels:
+    app: engine
+  name: engine-job-template-pytop-k80
+"
+`;
+
 exports[`Kapp Rules 1`] = `
 "apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
@@ -1146,158 +1298,6 @@ subjects:
 "
 `;
 
-exports[`NodeServer 2`] = `
-"apiVersion: v1
-kind: ServiceAccount
-imagePullSecrets:
-  - name: gcr-access-token
-metadata:
-  labels:
-    app: engine
-  name: engine-sa
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    app: engine
-  name: engine-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 250Gi
----
-apiVersion: v1
-kind: ConfigMap
-data:
-  job: |
-    metadata:
-      labels:
-        engineJob: 'true'
-        suffix: svcs
-    spec:
-      template:
-        spec:
-          serviceAccount: engine-sa
-          containers:
-            - image: gcr.io/tensorleap/engine:master-1234568-stable
-              name: engine
-              env:
-                - name: JOB_PAYLOAD
-                - name: PY_CONFIG
-                  value: /app/config/config.yaml
-                - name: ELASTIC_HOST
-                  value: http://elasticsearch-master.default:9200
-                - name: SESSION_BUCKET
-                  value: session
-                - name: RABBIT_HOST
-                  value: rabbitmq-headless
-                - name: RABBIT_USER
-                  value: user
-                - name: RABBIT_PASSWORD
-                  value: 3e3abae2-6325-11ec-90d6-0242ac120003
-                - name: FEEDBACK_TOPIC
-                  value: feedback
-                - name: SUBSCRIBER_TOPIC
-                  value: job-control-channel
-                - name: STORAGE_PROVIDER
-                  value: minio
-                - name: STORAGE_ENDPOINT
-                  value: dummy-minio
-                - name: STORAGE_PORT
-                  value: '9000'
-                - name: HMAC_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: minio-secret
-                      key: rootUser
-                - name: HMAC_ACCESS_KEY_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: minio-secret
-                      key: rootPassword
-              volumeMounts:
-                - name: engine-pvc
-                  mountPath: /nfs/
-          restartPolicy: Never
-          volumes:
-            - name: engine-pvc
-              presistentVolumeClaim:
-                claimName: engine-pvc
-metadata:
-  labels:
-    app: engine
-  name: engine-job-template-pytop-svcs
----
-apiVersion: v1
-kind: ConfigMap
-data:
-  job: |
-    metadata:
-      labels:
-        engineJob: 'true'
-        suffix: k80
-    spec:
-      template:
-        spec:
-          serviceAccount: engine-sa
-          containers:
-            - image: gcr.io/tensorleap/engine:master-1234568-stable
-              name: engine
-              resources:
-                limits:
-                  nvidia.com/gpu: 1
-              env:
-                - name: JOB_PAYLOAD
-                - name: PY_CONFIG
-                  value: /app/config/config.yaml
-                - name: ELASTIC_HOST
-                  value: http://elasticsearch-master.default:9200
-                - name: SESSION_BUCKET
-                  value: session
-                - name: RABBIT_HOST
-                  value: rabbitmq-headless
-                - name: RABBIT_USER
-                  value: user
-                - name: RABBIT_PASSWORD
-                  value: 3e3abae2-6325-11ec-90d6-0242ac120003
-                - name: FEEDBACK_TOPIC
-                  value: feedback
-                - name: SUBSCRIBER_TOPIC
-                  value: job-control-channel
-                - name: STORAGE_PROVIDER
-                  value: minio
-                - name: STORAGE_ENDPOINT
-                  value: dummy-minio
-                - name: STORAGE_PORT
-                  value: '9000'
-                - name: HMAC_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: minio-secret
-                      key: rootUser
-                - name: HMAC_ACCESS_KEY_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: minio-secret
-                      key: rootPassword
-              volumeMounts:
-                - name: engine-pvc
-                  mountPath: /nfs/
-          restartPolicy: Never
-          volumes:
-            - name: engine-pvc
-              presistentVolumeClaim:
-                claimName: engine-pvc
-metadata:
-  labels:
-    app: engine
-  name: engine-job-template-pytop-k80
-"
-`;
-
 exports[`RabbitMQ 1`] = `
 "apiVersion: v1
 kind: ServiceAccount
@@ -1641,7 +1641,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 8Gi
+            storage: 500Mi
 "
 `;
 

--- a/constructs/engine.ts
+++ b/constructs/engine.ts
@@ -40,7 +40,7 @@ export class Engine extends Chart {
         accessModes: ['ReadWriteMany'],
         resources: {
           requests: {
-            storage: Quantity.fromString('250Gi'),
+            storage: Quantity.fromString('20Gi'),
           },
         },
       },

--- a/constructs/rabbitmq.ts
+++ b/constructs/rabbitmq.ts
@@ -18,6 +18,9 @@ export class RabbitMQ extends Chart {
           password: '3e3abae2-6325-11ec-90d6-0242ac120003',
           erlangCookie: '3e3abae2-6325-11ec-90d6-0242ac120003',
         },
+        persistence: {
+          size: '500Mi',
+        },
       },
       helmFlags: [
         '--version=8.24.3',

--- a/main.test.ts
+++ b/main.test.ts
@@ -27,7 +27,7 @@ test('NodeServer', () => {
   expect(results).toMatchSnapshot();
 });
 
-test('NodeServer', () => {
+test('Engine', () => {
   const app = Testing.app();
   new Engine(app, {
     imageTag: 'master-1234568-stable',


### PR DESCRIPTION
Seems like we're asking alot.

After this `kubectl get pvc` shows:
```
NAME                                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
mongodb                                       Bound    pvc-a41af379-a940-4424-b138-b2610bb21d84   8Gi        RWO            microk8s-hostpath   19d
elasticsearch-master-elasticsearch-master-0   Bound    pvc-8f16f43f-201e-467b-9fb9-c43f5027ea96   30Gi       RWO            microk8s-hostpath   19d
minio-c8cb4064                                Bound    pvc-bfb695b4-ed73-4195-92d5-91a3d0bc7dc8   2Gi        RWO            microk8s-hostpath   19d
engine-pvc                                    Bound    pvc-640235b0-ad8b-4d05-8f42-7ef2f9d20fef   20Gi       RWX            microk8s-hostpath   6m
data-rabbitmq-0                               Bound    pvc-254bbfbf-2ebd-4bce-be5c-43078247f50e   500Mi      RWO            microk8s-hostpath   22s
```