### PR TITLE
Fix minio related signed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ Create a user using signup requests in http://tensorleap.local/api/v2/swagger
 ### On Ubuntu
 
 ```
-sudo apt-get update
+sudo apt update
+sudo apt upgrade
+
+# nvidia driver
+sudo apt install nvidia-driver-450
 
 # zsh
 sudo apt-get install -y zsh git vim
-ch -s $(which zsh) # restart after
+sudo chsh # change shell to /usr/bin/zsh and restart
 sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 

--- a/__snapshots__/main.test.ts.snap
+++ b/__snapshots__/main.test.ts.snap
@@ -1020,6 +1020,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: public
+    nginx.ingress.kubernetes.io/upstream-vhost: minio-c8cb4064:9000
   labels:
     app: minio
   name: minio

--- a/__snapshots__/main.test.ts.snap
+++ b/__snapshots__/main.test.ts.snap
@@ -321,6 +321,8 @@ data:
                   value: dummy-minio
                 - name: STORAGE_PORT
                   value: '9000'
+                - name: CONTENT_BASE_URL
+                  value: http://tensorleap.local/session/
                 - name: HMAC_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:
@@ -391,6 +393,8 @@ data:
                   value: dummy-minio
                 - name: STORAGE_PORT
                   value: '9000'
+                - name: CONTENT_BASE_URL
+                  value: http://tensorleap.local/session/
                 - name: HMAC_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:

--- a/__snapshots__/main.test.ts.snap
+++ b/__snapshots__/main.test.ts.snap
@@ -1101,6 +1101,8 @@ spec:
                 secretKeyRef:
                   key: rootPassword
                   name: minio-secret
+            - name: SIGNED_URL_HOST_REPLACEMENT
+              value: tensorleap.local
           image: gcr.io/tensorleap/node-server:master-1234568-stable
           imagePullPolicy: Always
           name: node-server

--- a/constructs/engine.ts
+++ b/constructs/engine.ts
@@ -177,6 +177,10 @@ class EngineConfigMap {
                     value: '9000',
                   },
                   {
+                    name: 'CONTENT_BASE_URL',
+                    value: 'http://tensorleap.local/session/',
+                  },
+                  {
                     name: 'HMAC_ACCESS_KEY_ID',
                     valueFrom: {
                       secretKeyRef: {

--- a/constructs/minio.ts
+++ b/constructs/minio.ts
@@ -51,6 +51,7 @@ export class Minio extends Chart {
       metadata: {
         annotations: {
           'kubernetes.io/ingress.class': 'public',
+          'nginx.ingress.kubernetes.io/upstream-vhost': `${minio.releaseName}:9000`,
         },
         name: 'minio',
       },

--- a/constructs/node-server.ts
+++ b/constructs/node-server.ts
@@ -170,6 +170,10 @@ export class NodeServer extends Chart {
                       },
                     },
                   },
+                  {
+                    name: 'SIGNED_URL_HOST_REPLACEMENT',
+                    value: 'tensorleap.local',
+                  },
                 ],
               },
             ],

--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,7 @@ new Kibana(app);
 const minio = new Minio(app);
 new RabbitMQ(app);
 new NodeServer(app, {
-  imageTag: 'master-863ed9f4-stable',
+  imageTag: 'master-ec40fe36-stable',
   minioAddress: minio.minioAddress,
 });
 new Engine(app, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "cdk8s": "^1.4.4",
+        "cdk8s": "^1.4.6",
         "cdk8s-plus-22": "^1.0.0-beta.54",
         "constructs": "^3.3.161",
         "js-yaml": "^4.1.0"
@@ -20,7 +20,7 @@
         "@types/node": "^16.11.11",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
-        "cdk8s-cli": "^1.0.78",
+        "cdk8s-cli": "^1.0.79",
         "eslint": "^8.3.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/cdk8s": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.4.tgz",
-      "integrity": "sha512-gNX7V73tqU3OVm8HEinckUpzwrCDCp0k3hZRmx2GTJ4R3vT1b9bnVk9eyCJL0ckML5r94lPNg48fBzGAUTr0IA==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.6.tgz",
+      "integrity": "sha512-LAUIvbIVq8qNVHn5CEnUpFlbpvgsUrXW1fj7BDgBu0FGODdUjab5iUYZjMT/3Cao8I+mQj4xLfvkhzl5uYXIAA==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -1945,27 +1945,27 @@
         "node": ">= 12.13.0"
       },
       "peerDependencies": {
-        "constructs": "^3.3.190"
+        "constructs": "^3.3.192"
       }
     },
     "node_modules/cdk8s-cli": {
-      "version": "1.0.78",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.78.tgz",
-      "integrity": "sha512-yL7vfHNs1APyaxHvBhRgl5IvgYTPMdGiAiNGF8NVcimj6CFykMJeV2LB4dP2olZxWYOUSb3qwGXgnU0uQp/gaQ==",
+      "version": "1.0.79",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.79.tgz",
+      "integrity": "sha512-ybN6kjvtgvlRBfMbW453kxPHX0c71dBbDIWt4/m0FOoyXOmfFeXs8+wFd6Gb7YeWb0PTWMZKZ89znLWTY7RUhg==",
       "dev": true,
       "dependencies": {
         "@types/node": "^12.13.0",
         "ajv": "^8.9.0",
-        "cdk8s": "^1.4.2",
-        "cdk8s-plus-22": "^1.0.0-beta.87",
+        "cdk8s": "^1.4.5",
+        "cdk8s-plus-22": "^1.0.0-beta.91",
         "codemaker": "^1.52.1",
         "colors": "1.4.0",
-        "constructs": "^3.3.189",
+        "constructs": "^3.3.192",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.52.1",
-        "jsii-srcmak": "^0.1.446",
-        "json2jsii": "^0.2.106",
-        "sscaff": "^1.2.172",
+        "jsii-srcmak": "^0.1.449",
+        "json2jsii": "^0.2.109",
+        "sscaff": "^1.2.175",
         "yaml": "2.0.0-10",
         "yargs": "^15"
       },
@@ -2058,9 +2058,9 @@
       }
     },
     "node_modules/cdk8s-plus-22": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.89.tgz",
-      "integrity": "sha512-+FW+3wGaDvvhbrxHfsDnfpcyg44WkMN9LhMNfuMVXt9da5eaJQ0zujtWVw6xuqHESjN5O3WZ+4ThIEuwmM9IHw==",
+      "version": "1.0.0-beta.92",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.92.tgz",
+      "integrity": "sha512-aUVonmiwleSOz8lCO9Vk5aNkY45gpuGBef2il1U7mr7ed+kDBZ/Mi9wrehx2A9LQ4pWiMVf9MUHg1FKyqdbSbQ==",
       "bundleDependencies": [
         "minimatch"
       ],
@@ -2071,8 +2071,8 @@
         "node": ">= 12.13.0"
       },
       "peerDependencies": {
-        "cdk8s": "^1.4.3",
-        "constructs": "^3.3.190"
+        "cdk8s": "^1.4.5",
+        "constructs": "^3.3.192"
       }
     },
     "node_modules/cdk8s-plus-22/node_modules/balanced-match": {
@@ -2461,9 +2461,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "3.3.191",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.191.tgz",
-      "integrity": "sha512-u1ZkZYnt/v0qNxPV2FsGeCTpTYQGG6lBEpWt/+RSIRjwdQrLcADttULB14nRxpMWgXkgEv3NperwqKYJFlwbLA==",
+      "version": "3.3.193",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.193.tgz",
+      "integrity": "sha512-85lCvrPlrlTnKS/rpl/jiB9y5t4GGWHhubRP3hlQbKiGAeQ2VIqcjODsU5oorrDi5JzDxcdZ83vfPtP1RtELWA==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -2530,9 +2530,9 @@
       }
     },
     "node_modules/date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
+      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -3389,16 +3389,10 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flat-cache/node_modules/flatted": {
+    "node_modules/flatted": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
-      "dev": true
-    },
-    "node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "node_modules/foreach": {
@@ -5190,9 +5184,9 @@
       }
     },
     "node_modules/jsii-srcmak": {
-      "version": "0.1.448",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.448.tgz",
-      "integrity": "sha512-sDlXtDI3SfOlnaSijwVqMyRAw/ZMA5xzwmnvdqOlv/O1sjCc1owMi8NKspudYz6zbkF+eqnJ+7gQQ+uTRLdGfA==",
+      "version": "0.1.450",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.450.tgz",
+      "integrity": "sha512-U19pmnYVUympcwhvtFDsyawU5Gth3f7EGuCABHBEW52LhxEmaBId/hqhGXmZcPO6oE6q+/IJohQrlwEDQN02PQ==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
@@ -5399,9 +5393,9 @@
       "dev": true
     },
     "node_modules/json2jsii": {
-      "version": "0.2.108",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.108.tgz",
-      "integrity": "sha512-JezzCy8XZiGvIbboPsWDOF5o238jTaMvmQuELBwWEubHo5v7dT83HSvZktKGLdVyvYqcxDZYXj1wT4L1iAEEVQ==",
+      "version": "0.2.110",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.110.tgz",
+      "integrity": "sha512-Wf5KIfwmMS2XEpO4wdVMgLgVMr7dVZ2c4j0U+WWEPZq8iYLXawEQAs0HSFXtzxne1s++2fuCZHnRxcPGj5t8Iw==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -5686,16 +5680,16 @@
       }
     },
     "node_modules/log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.0.tgz",
+      "integrity": "sha512-ysc/XUecZJuN8NoKOssk3V0cQ29xY4fra6fnigZa5VwxFsCsvdqsdnEuAxNN89LlHpbE4KUD3zGcn+kFqonSVQ==",
       "dev": true,
       "dependencies": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
+        "date-format": "^4.0.3",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.4",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.2"
       },
       "engines": {
         "node": ">=8.0"
@@ -6692,9 +6686,9 @@
       "dev": true
     },
     "node_modules/sscaff": {
-      "version": "1.2.174",
-      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.174.tgz",
-      "integrity": "sha512-aXHcSIwG1/MxXuAZYI/LAAH6DMBu+F+qSAZsoCbJb6K3ri0iZz2JTV525vPUMZm3gWnLwvt7+tns+llG9L64iQ==",
+      "version": "1.2.176",
+      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.176.tgz",
+      "integrity": "sha512-kf9+Di68+XEj4EQb1VJd/53xD23fOUxlKDASlrgv02X1ZVecySxpmSppg8PnBaxYh79dGvUXBCx0yIhXQjGkJQ==",
       "dev": true,
       "engines": {
         "node": ">= 12.13.0"
@@ -6713,26 +6707,52 @@
       }
     },
     "node_modules/streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
+      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
       "dev": true,
       "dependencies": {
-        "date-format": "^2.1.0",
+        "date-format": "^4.0.3",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
+        "fs-extra": "^10.0.0"
       },
       "engines": {
         "node": ">=8.0"
       }
     },
-    "node_modules/streamroller/node_modules/date-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-      "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+    "node_modules/streamroller/node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/streamroller/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/streamroller/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
       "engines": {
-        "node": ">=4.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/string-argv": {
@@ -8910,9 +8930,9 @@
       "dev": true
     },
     "cdk8s": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.4.tgz",
-      "integrity": "sha512-gNX7V73tqU3OVm8HEinckUpzwrCDCp0k3hZRmx2GTJ4R3vT1b9bnVk9eyCJL0ckML5r94lPNg48fBzGAUTr0IA==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.6.tgz",
+      "integrity": "sha512-LAUIvbIVq8qNVHn5CEnUpFlbpvgsUrXW1fj7BDgBu0FGODdUjab5iUYZjMT/3Cao8I+mQj4xLfvkhzl5uYXIAA==",
       "requires": {
         "fast-json-patch": "^2.2.1",
         "follow-redirects": "^1.14.7",
@@ -8943,23 +8963,23 @@
       }
     },
     "cdk8s-cli": {
-      "version": "1.0.78",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.78.tgz",
-      "integrity": "sha512-yL7vfHNs1APyaxHvBhRgl5IvgYTPMdGiAiNGF8NVcimj6CFykMJeV2LB4dP2olZxWYOUSb3qwGXgnU0uQp/gaQ==",
+      "version": "1.0.79",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.79.tgz",
+      "integrity": "sha512-ybN6kjvtgvlRBfMbW453kxPHX0c71dBbDIWt4/m0FOoyXOmfFeXs8+wFd6Gb7YeWb0PTWMZKZ89znLWTY7RUhg==",
       "dev": true,
       "requires": {
         "@types/node": "^12.13.0",
         "ajv": "^8.9.0",
-        "cdk8s": "^1.4.2",
-        "cdk8s-plus-22": "^1.0.0-beta.87",
+        "cdk8s": "^1.4.5",
+        "cdk8s-plus-22": "^1.0.0-beta.91",
         "codemaker": "^1.52.1",
         "colors": "1.4.0",
-        "constructs": "^3.3.189",
+        "constructs": "^3.3.192",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.52.1",
-        "jsii-srcmak": "^0.1.446",
-        "json2jsii": "^0.2.106",
-        "sscaff": "^1.2.172",
+        "jsii-srcmak": "^0.1.449",
+        "json2jsii": "^0.2.109",
+        "sscaff": "^1.2.175",
         "yaml": "2.0.0-10",
         "yargs": "^15"
       },
@@ -9036,9 +9056,9 @@
       }
     },
     "cdk8s-plus-22": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.89.tgz",
-      "integrity": "sha512-+FW+3wGaDvvhbrxHfsDnfpcyg44WkMN9LhMNfuMVXt9da5eaJQ0zujtWVw6xuqHESjN5O3WZ+4ThIEuwmM9IHw==",
+      "version": "1.0.0-beta.92",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.92.tgz",
+      "integrity": "sha512-aUVonmiwleSOz8lCO9Vk5aNkY45gpuGBef2il1U7mr7ed+kDBZ/Mi9wrehx2A9LQ4pWiMVf9MUHg1FKyqdbSbQ==",
       "requires": {
         "minimatch": "^3.0.4"
       },
@@ -9298,9 +9318,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "3.3.191",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.191.tgz",
-      "integrity": "sha512-u1ZkZYnt/v0qNxPV2FsGeCTpTYQGG6lBEpWt/+RSIRjwdQrLcADttULB14nRxpMWgXkgEv3NperwqKYJFlwbLA=="
+      "version": "3.3.193",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.193.tgz",
+      "integrity": "sha512-85lCvrPlrlTnKS/rpl/jiB9y5t4GGWHhubRP3hlQbKiGAeQ2VIqcjODsU5oorrDi5JzDxcdZ83vfPtP1RtELWA=="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -9357,9 +9377,9 @@
       }
     },
     "date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
+      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
       "dev": true
     },
     "debug": {
@@ -9993,20 +10013,12 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
-      },
-      "dependencies": {
-        "flatted": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-          "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
-          "dev": true
-        }
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
     "foreach": {
@@ -11378,9 +11390,9 @@
       }
     },
     "jsii-srcmak": {
-      "version": "0.1.448",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.448.tgz",
-      "integrity": "sha512-sDlXtDI3SfOlnaSijwVqMyRAw/ZMA5xzwmnvdqOlv/O1sjCc1owMi8NKspudYz6zbkF+eqnJ+7gQQ+uTRLdGfA==",
+      "version": "0.1.450",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.450.tgz",
+      "integrity": "sha512-U19pmnYVUympcwhvtFDsyawU5Gth3f7EGuCABHBEW52LhxEmaBId/hqhGXmZcPO6oE6q+/IJohQrlwEDQN02PQ==",
       "dev": true,
       "requires": {
         "fs-extra": "^9.1.0",
@@ -11502,9 +11514,9 @@
       "dev": true
     },
     "json2jsii": {
-      "version": "0.2.108",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.108.tgz",
-      "integrity": "sha512-JezzCy8XZiGvIbboPsWDOF5o238jTaMvmQuELBwWEubHo5v7dT83HSvZktKGLdVyvYqcxDZYXj1wT4L1iAEEVQ==",
+      "version": "0.2.110",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.110.tgz",
+      "integrity": "sha512-Wf5KIfwmMS2XEpO4wdVMgLgVMr7dVZ2c4j0U+WWEPZq8iYLXawEQAs0HSFXtzxne1s++2fuCZHnRxcPGj5t8Iw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -11711,16 +11723,16 @@
       }
     },
     "log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.0.tgz",
+      "integrity": "sha512-ysc/XUecZJuN8NoKOssk3V0cQ29xY4fra6fnigZa5VwxFsCsvdqsdnEuAxNN89LlHpbE4KUD3zGcn+kFqonSVQ==",
       "dev": true,
       "requires": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
+        "date-format": "^4.0.3",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.4",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.2"
       }
     },
     "lower-case": {
@@ -12455,9 +12467,9 @@
       "dev": true
     },
     "sscaff": {
-      "version": "1.2.174",
-      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.174.tgz",
-      "integrity": "sha512-aXHcSIwG1/MxXuAZYI/LAAH6DMBu+F+qSAZsoCbJb6K3ri0iZz2JTV525vPUMZm3gWnLwvt7+tns+llG9L64iQ==",
+      "version": "1.2.176",
+      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.176.tgz",
+      "integrity": "sha512-kf9+Di68+XEj4EQb1VJd/53xD23fOUxlKDASlrgv02X1ZVecySxpmSppg8PnBaxYh79dGvUXBCx0yIhXQjGkJQ==",
       "dev": true
     },
     "stack-utils": {
@@ -12470,20 +12482,41 @@
       }
     },
     "streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
+      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
       "dev": true,
       "requires": {
-        "date-format": "^2.1.0",
+        "date-format": "^4.0.3",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
+        "fs-extra": "^10.0.0"
       },
       "dependencies": {
-        "date-format": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "cdk8s": "^1.4.4",
+    "cdk8s": "^1.4.6",
     "cdk8s-plus-22": "^1.0.0-beta.54",
     "constructs": "^3.3.161",
     "js-yaml": "^4.1.0"
@@ -29,7 +29,7 @@
     "@types/node": "^16.11.11",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
-    "cdk8s-cli": "^1.0.78",
+    "cdk8s-cli": "^1.0.79",
     "eslint": "^8.3.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",


### PR DESCRIPTION
After this is deployed, `node-server` edits the hostname is the signed urls, then `nginx` edits them back, so `minio` doesn't know the difference.

Before merging, merge https://github.com/tensorleap/node-server/pull/487 and replace the last commit with the new node-server tag

also in this PR small updates in readme (after upgrading ubuntu, how I installed the driver) and upgrade the `cdk8s`